### PR TITLE
Map iScroll onScrollMove and onScrollEnd events

### DIFF
--- a/src/mobile/skrollr.mobile.js
+++ b/src/mobile/skrollr.mobile.js
@@ -11,7 +11,7 @@
 	 * document.addEventListener('skrollrOnScrollMove', function(e) { // var iScroll = e.context });
 	 */
 	function emitEvent(name, context) {
-	    var evt = document.createEvent("Events")
+	    var evt = document.createEvent("Events");
 	    evt.initEvent(name, true, true); //true for can bubble, true for cancelable
 	    evt.context = context;
 	    document.dispatchEvent(evt);


### PR DESCRIPTION
In case you need a simple .onScroll() event for mobile devices (as window.scroll doesn't fire), this now maps the iScroll events to a custom skrollr event.

For example (only for mobile code):

```
document.addEventListener('skrollrOnScrollMove', function(e) {
    var iScrollInstance = e.context;
    console.log('move', iScrollInstance);
});

document.addEventListener('skrollrOnScrollEnd', function(e) {
    var iScrollInstance = e.context;
    console.log('end', iScrollInstance);
});
```

Note I haven't compiled this with grunt, only src files updated.
