### PR TITLE
Add link to Rails gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Further resources (tutorials etc.)
 * http://www.guardian.co.uk/info/developer-blog/2012/nov/20/how-we-built-america-elect-graphic-novel-interactive
 * http://webdesign.tutsplus.com/tutorials/htmlcss-tutorials/jazz-up-a-static-webpage-with-subtle-parallax/
 * http://pepsized.com/merry-scrolling-with-skrollr-js/
+* https://rubygems.org/gems/skrollr-rails
 
 _Want to get added? Just fork & pull request or tweet me [@Prinzhorn](https://twitter.com/Prinzhorn)_
 


### PR DESCRIPTION
I wrapped this fantastic library in a ruby gem so I could easily integrate it into my Rails app.  This PR adds a link to the readme in case anybody else wants to use it.  
