### PR TITLE
Moved length checks outside of loop.

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -1147,9 +1147,9 @@
 
 		//All classes to be added.
 		var classAddIndex = 0;
-		var addIndex = add.length;
+		var addLength = add.length;
 
-		for(; classAddIndex < addIndex; classAddIndex++) {
+		for(; classAddIndex < addLength; classAddIndex++) {
 			//Only add if el not already has class.
 			if(_untrim(val).indexOf(_untrim(add[classAddIndex])) === -1) {
 				val += ' ' + add[classAddIndex];


### PR DESCRIPTION
When a loop runs, the check gets processed each time. Since the length of these loops are not changing, checking their length each time is unnecessary. This allows us to assign a variable that stores the length we will check against.
