### PR TITLE
use window height for viewport height instead of document height

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -506,7 +506,7 @@
 	 * That is, calculate anchor position and offset of element.
 	 */
 	Skrollr.prototype.relativeToAbsolute = function(element, viewportAnchor, elementAnchor) {
-		var viewportHeight = documentElement.clientHeight;
+		var viewportHeight = window.innerHeight;
 		var box = element.getBoundingClientRect();
 		var absolute = box.top;
 


### PR DESCRIPTION
translation from relative to absolute coordinates should be (as it is in documentation and also it is somehow logical) relative to browser's viewport edges. Thus viewport height is not document height but browser's window inner height.
