### PR TITLE
Fixed mobile scrolling over input, text elements

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -718,9 +718,11 @@
 
 					break;
 				case EVENT_TOUCHMOVE:
+					// Prevent default event on touchIgnore elements in case they don't have a focus yet
 					if(rxTouchIgnoreTags.test(currentElement.tagName) && document.activeElement != currentElement) {
 						e.preventDefault();
 					}
+
 					deltaY = currentTouchY - lastTouchY;
 					deltaTime = currentTouchTime - lastTouchTime;
 


### PR DESCRIPTION
Preventing default event over input, text elements in case they dont have a focus yet otherwise use default event propagation. Tested on Android - 2.3, 4.0.4, Iphone - 5s, 3gs.

https://github.com/Prinzhorn/skrollr/issues/397
