### PR TITLE
windows phone works similar to desktop, so mobile mode is not desire

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -270,7 +270,7 @@
 
 		//A custom check function may be passed.
 		_isMobile = ((options.mobileCheck || function() {
-			return (/Android|iPhone|iPad|iPod|BlackBerry|Windows Phone/i).test(navigator.userAgent || navigator.vendor || window.opera);
+			return (/Android|iPhone|iPad|iPod|BlackBerry/i).test(navigator.userAgent || navigator.vendor || window.opera);
 		})());
 
 		if(_isMobile) {


### PR DESCRIPTION
Internet Explorer on Windows Phone 8 act very similar to desktop (in matter of scroll events), so there is no need to use transform translate. On Windows Phone 7 it doesn't work anyway because there is no support of CSS3 transform.
