### PR TITLE
Allow NodeList as the .refresh() argument

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -333,7 +333,7 @@
 			elements = document.getElementsByTagName('*');
 		} else {
 			//We accept a single element or an array of elements.
-			elements = [].concat(elements);
+			elements = [].slice.apply(elements);
 		}
 
 		elementIndex = 0;


### PR DESCRIPTION
`.refresh()` wasn't accepting the result of `querySelectorAll()` like the docs say it does. This way any argument is _cast_ into an array.
