### PR TITLE
Fix _smoothScrolling state at animateTo animation end

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -572,6 +572,10 @@
 			_scrollAnimation.done.call(_instance, true);
 		}
 
+		if(_smoothScrolling) {
+			_smoothScrolling.targetTop = _instance.getScrollTop(); //Update smooth scroll data so we don't scroll in next _render loop
+		}
+
 		_scrollAnimation = undefined;
 	};
 
@@ -1006,6 +1010,9 @@
 			//It's over
 			if(now >= _scrollAnimation.endTime) {
 				renderTop = _scrollAnimation.targetTop;
+				if(_smoothScrolling) {
+					_smoothScrolling.targetTop = _instance.getScrollTop(); //Update smooth scroll data so we don't scroll in next _render loop
+				}
 				afterAnimationCallback = _scrollAnimation.done;
 				_scrollAnimation = undefined;
 			} else {


### PR DESCRIPTION
Update the state of _smoothScrolling state when animateTo animation ends
so that the smooth scroll doesn't trigger on the next render loop.
