### PR TITLE
Width and height are updated incorrectly after orientationchange event

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -290,20 +290,22 @@
 		//Triggers parsing of elements and a first reflow.
 		_instance.refresh();
 
-		_addEvent(window, 'resize orientationchange', function() {
-			var width = documentElement.clientWidth;
-			var height = documentElement.clientHeight;
-
-			//Only reflow if the size actually changed (#271).
-			if(height !== _lastViewportHeight || width !== _lastViewportWidth) {
-				_lastViewportHeight = height;
-				_lastViewportWidth = width;
-
-				_requestReflow = true;
-			}
-		});
-
 		var requestAnimFrame = polyfillRAF();
+
+		_addEvent(window, 'resize orientationchange', function() {
+			requestAnimFrame(function() {
+				var width = documentElement.clientWidth;
+				var height = documentElement.clientHeight;
+
+				//Only reflow if the size actually changed (#271).
+				if(height !== _lastViewportHeight || width !== _lastViewportWidth) {
+					_lastViewportHeight = height;
+					_lastViewportWidth = width;
+
+					_requestReflow = true;
+				}
+			});
+		});
 
 		//Let's go.
 		(function animloop(){


### PR DESCRIPTION
When orientationchange event occurs, client width and height are sometimes wrong especially for large webpages. Reason is that rendering has not finished. This can result in window scroll div height being set to wrong height after orientation change. Waiting for browser to finish rendering should fix this.
