### PR TITLE
Refresh bugfix

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -352,7 +352,7 @@
 
 			// If we're reseting the counter, remove any old element ids that may be hanging around.
 			if(ignoreID) {
-				delete el[SKROLLABLE_ID_DOM_PROPERTY]
+				delete el[SKROLLABLE_ID_DOM_PROPERTY];
 			}
 
 			if(!el.attributes) {


### PR DESCRIPTION
A small bugfix.

A bit of background. I was calling refresh (without any arguments) after editing the skrollr `data-` attributes on a bunch of elements. On a few elements, I'd removed the skrollr attributes all together, such that skrollr should no longer be managing those elements. However, their `___skrollable_id` properties were being left on them in the DOM. The result was that, when skrollr looped through the elements with `___skrollable_id`s in order to build the internal object for each one, it found multiple DOM elements with the same `___skrollable_id` in some cases (as the id counter had been reset). This caused the keyframe objects to get messed up, with the empty keyframe properties from the now-unmanaged elements sometimes overwriting the legitimate keyframe properties other element with the same id.
