### PR TITLE
Expose isMobile in the public API

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -581,7 +581,7 @@
 	Skrollr.prototype.isAnimatingTo = function() {
 		return !!_scrollAnimation;
 	};
-	
+
 	Skrollr.prototype.isMobile = function() {
 		return _isMobile;
 	};


### PR DESCRIPTION
Whether skrollr's running in mobile can affect things the developer cares about, so skrollr should expose this property.

I'll give just one example that I ran into. I wanted to calculate a (`position:static`) element's offset from the top of the document, in order to answer the question "How far would the user have to scroll for this element to come into view?" The idea was to animate a different (fixed) element as static element came into view. When skrollr's running in desktop mode, calculating this offset is easy (it's basically `element.getBoundingClientRect() + window.pageYOffset()`, which is the element's position in the viewport + how far the user has scrolled). But, for mobile, `pageYOffset` always stays at 0, while the CSS transforms [affect](http://www.w3.org/TR/cssom-view/#dom-element-getclientrects) the result from `getBoudingClientRectangle`, the result being that the same calculation yields an invalid offset. But if I could detect whether skrollr were running in mobile, this would be easy to adjust for.
