### PR TITLE
Hotfixed IE8 bug: Object doesn't support this property or method

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -357,7 +357,7 @@
 			var emitEvents = false;
 
 			//If we're reseting the counter, remove any old element ids that may be hanging around.
-			if(ignoreID && el[SKROLLABLE_ID_DOM_PROPERTY]) {
+			if(ignoreID && SKROLLABLE_ID_DOM_PROPERTY in el) {
 				delete el[SKROLLABLE_ID_DOM_PROPERTY];
 			}
 


### PR DESCRIPTION
skrollr.js, line 361 character 5 
(minified version skrollr.min.js, line 2 character 2901)

Not sure if this is the best way to fix it, but it does the trick :).
