### PR TITLE
destroy now only sets body height to auto if forceHeight = true

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -633,7 +633,10 @@
 		}
 
 		documentElement.style.overflow = body.style.overflow = 'auto';
-		documentElement.style.height = body.style.height = 'auto';
+
+        if(_forceHeight) {
+            documentElement.style.height = body.style.height = 'auto';
+        }
 
 		if(_skrollrBody) {
 			skrollr.setStyle(_skrollrBody, 'transform', 'none');


### PR DESCRIPTION
The `destroy` function of Skrollr now only sets the body style to auto if `_forceHeight == true`. Otherwise the body.style should remain untouched. 

This was breaking responsive designs.
