### PR TITLE
Update for easing function names regexp

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -70,7 +70,7 @@
 	var rxPropValue = /\s*(@?[\w\-\[\]]+)\s*:\s*(.+?)\s*(?:;|$)/gi;
 
 	//Easing function names follow the property in square brackets.
-	var rxPropEasing = /^([a-z\-@]+)\[(\w+)\]$/;
+	var rxPropEasing = /^(@?[a-z\-]+)\[(\w+)\]$/;
 
 	var rxCamelCase = /-([a-z0-9_])/g;
 	var rxCamelCaseFn = function(str, letter) {


### PR DESCRIPTION
A tiny update that fixes the bug when trying to apply easing function on attribute animation. Current regexp works fine when you use something like "left[outCubic]: 50px" but fails on "@data-num[outCubic]: 100".
