### PR TITLE
Adding a new parameter: _precision.

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -240,7 +240,7 @@
 				easings[e] = options.easing[e];
 			}
 		}
-		
+
 		_precision = parseInt(options.precision, 10) || 10;
 
 		_edgeStrategy = options.edgeStrategy || 'set';


### PR DESCRIPTION
The interpolation of values could result in values with decimals of an extremely long length, e.g. 'width: 50.12345678901%'.  Since scrolling causes browser repaints, which will be impacted by updated CSS values, performance can be negatively impacted.

I'm proposing a new init option: _precision. This will be used to limit the interpolated value returned from _calcInterpolation via the toFixed(n) method.  The default will be 10 (which is likely more than enough for most use-cases) or the user-specified value.
