### PR TITLE
tweaked define module to play a bit nicer with requirejs

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -1759,7 +1759,7 @@
 
 	//Expose skrollr as either a global variable or a require.js module.
 	if(typeof define === 'function' && define.amd) {
-		define('skrollr', function () {
+		define([], function () {
 			return skrollr;
 		});
 	} else if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
In implementing skrollr into my requirejs modules per the README, I noticed that by giving the module a name, skrollr kept coming back as `undefined`. After drilling down a bit through the source code with another dev I found that by removing the naming of the define module, it was able to return the skrollr object to my requirejs modules. Interested to see if this is a fix that works for more people as well.
