### PR TITLE
Suggested redo for snap scroller based on classname 

### DIFF
--- a/snap.html
+++ b/snap.html
@@ -65,7 +65,7 @@
 		</div>
 	</div>
 
-	<script type="text/javascript" src="dist/skrollrmin.js"></script>
+	<script type="text/javascript" src="dist/skrollr.min.js"></script>
 	<script type="text/javascript">
    layers = document.getElementsByClassName("snap");
 var activeLayer = 0;


### PR DESCRIPTION
Redid the old snap scroller example.  Works better for me.  Handles top/bottom cases better.   Based it on classname for greater flexibility.
