### PR TITLE
Minor: Removed grave accent from “ìnit”

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Check out the [skrollr-menu](https://github.com/Prinzhorn/skrollr-menu) plugin.
 Working with constants
 -----
 
-I was lying to you. The syntax for absolute mode is not `data-[offset]-[anchor]` and for relative mode it's not `data-[offset]-(viewport-anchor)-[element-anchor]`. In both cases, `offset` can be preceded by a constant which can be passed to the `ìnit` method. The name of the constant needs to be preceded with an underscore.
+I was lying to you. The syntax for absolute mode is not `data-[offset]-[anchor]` and for relative mode it's not `data-[offset]-(viewport-anchor)-[element-anchor]`. In both cases, `offset` can be preceded by a constant which can be passed to the `init` method. The name of the constant needs to be preceded with an underscore.
 
 Example:
 


### PR DESCRIPTION
One of the mentions of the `init` method strangely had a initial grave-accent-“i” (“ì”), which appears to be a typo (didn't match the other usages and doesn't make sense in the context of programming).  Fixed by changing to a standard “i”.
