### PR TITLE
Add forceHeight: 'content' option for mobile

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -255,7 +255,7 @@
 		};
 
 		//forceHeight is true by default
-		_forceHeight = options.forceHeight !== false;
+		_forceHeight = typeof options.forceHeight !== 'undefined' ? options.forceHeight : true;
 
 		if(_forceHeight) {
 			_scale = options.scale || 1;
@@ -834,6 +834,9 @@
 		var skrollablesLength;
 		var offset;
 		var constantValue;
+		var child;
+		var maxChild;
+		var i;
 
 		//First process all relative-mode elements and find the max key frame.
 		skrollableIndex = 0;
@@ -875,7 +878,7 @@
 				kf.frame += constantValue;
 
 				//Only search for max key frame when forceHeight is enabled.
-				if(_forceHeight) {
+				if(_forceHeight === true) {
 					//Find the max key frame, but don't use one of the data-end ones for comparison.
 					if(!kf.isEnd && kf.frame > _maxKeyFrame) {
 						_maxKeyFrame = kf.frame;
@@ -883,6 +886,18 @@
 				}
 			}
 		}
+
+		// Sometimes ending keyframes occur beyond the default boundary of the page as
+		// defined by the elements within the skrollr-body on mobile browsers. This measures
+		// the content of skrollr-body and adjusts _maxKeyFrame accordingly.
+		if (_forceHeight === 'content' && _isMobile) {
+			for (i = 0; i < _skrollrBody.children.length; i++) {
+				child = _skrollrBody.children[i];
+				maxChild = Math.max(maxChild || 0, _skrollrBody.offsetTop + child.offsetTop + child.clientHeight);
+			}
+			_maxKeyFrame = maxChild - documentElement.clientHeight;
+		}
+
 
 		//#133: The document can be larger than the maxKeyFrame we found.
 		_maxKeyFrame = Math.max(_maxKeyFrame, _getDocumentHeight());


### PR DESCRIPTION
I kept having issues on mobile browsers in situations where I had keyframes that didn't 'end' until after the end of the content. When using forceHeight, the height is expanded to allow all keyframes to be
reachable by extending the page content beyond where it would normally end. This small change adds a 'content' option for forceHeight which measures the elements within the skrollr-body and adjusts the maximum scroll area to be within the boundaries of the page content, regardless of the final keyframe(s).

I'm not sure if this is the proper way to address this issue, but it seems like other people have been having similar issues with extraneous content at the end of their pages.

Thanks!
