### PR TITLE
Little and fast optimisation

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -31,6 +31,7 @@
 	var documentElement;
 	var body;
 
+	var IS_ENABLED = true;
 	var EVENT_TOUCHSTART = 'touchstart';
 	var EVENT_TOUCHMOVE = 'touchmove';
 	var EVENT_TOUCHCANCEL = 'touchcancel';
@@ -525,6 +526,18 @@
 		return _instance;
 	};
 
+	Skrollr.prototype.enable = function(){
+
+		IS_ENABLED = true;
+
+	};
+
+	Skrollr.prototype.disable = function(){
+
+		IS_ENABLED = false;
+
+	};
+
 	/**
 	 * Transform "relative" mode to "absolute" mode.
 	 * That is, calculate anchor position and offset of element.
@@ -712,6 +725,13 @@
 		var deltaTime;
 
 		_addEvent(documentElement, [EVENT_TOUCHSTART, EVENT_TOUCHMOVE, EVENT_TOUCHCANCEL, EVENT_TOUCHEND].join(' '), function(e) {
+			
+			if( IS_ENABLED == false ){
+
+				return;
+
+			};
+
 			var touch = e.changedTouches[0];
 
 			currentElement = e.target;

--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -675,8 +675,8 @@
 		_scale = 1;
 		_constants = undefined;
 		_mobileDeceleration = undefined;
-		_direction = 'down';
-		_lastTop = -1;
+		_direction = 0;
+		_lastTop = 0;
 		_lastViewportWidth = 0;
 		_lastViewportHeight = 0;
 		_requestReflow = false;
@@ -1040,7 +1040,7 @@
 					if(emitEvents) {
 						//Did we pass a new keyframe?
 						if(lastFrameIndex !== keyFrameIndex) {
-							if(_direction === 'down') {
+							if(_direction === 1) {
 								_emitEvent(element, left.eventType, _direction);
 							} else {
 								_emitEvent(element, right.eventType, _direction);
@@ -1122,7 +1122,7 @@
 		//Did the scroll position even change?
 		if(_forceRender || _lastTop !== renderTop) {
 			//Remember in which direction are we scrolling?
-			_direction = (renderTop > _lastTop) ? 'down' : (renderTop < _lastTop ? 'up' : _direction);
+			_direction = (renderTop > _lastTop) ? 1 : (renderTop < _lastTop ? 0 : _direction);
 
 			_forceRender = false;
 
@@ -1716,10 +1716,10 @@
 	var _mobileDeceleration;
 
 	//Current direction (up/down).
-	var _direction = 'down';
+	var _direction = 0;
 
 	//The last top offset value. Needed to determine direction.
-	var _lastTop = -1;
+	var _lastTop = 0;
 
 	//The last time we called the render method (doesn't mean we rendered!).
 	var _lastRenderCall = _now();


### PR DESCRIPTION
Change _direction from string to int, 0 for up and 1 for down. Cause comparing a string is a realy bad idea in a rendering loop.
Change initial _lastTop from -1 to 0 to avoid render saying « i'm scrolling down about 1px » at site load.