### PR TITLE
Marking the project as "javascript"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+examples/* linguist-vendored
+guide/* linguist-vendored
+test/* linguist-vendored


### PR DESCRIPTION
![html](https://cloud.githubusercontent.com/assets/1706326/6750226/1c3900d2-cef0-11e4-83ce-37497e4323d1.PNG)

Due to some recent changes in github skrollr.js is marked as an HTML project, which is far from ideal.
For example, it won't appear in the [most popular / forked repositories in the Javascript category](https://github.com/search?l=JavaScript&q=stars%3A%3E1&s=stars&type=Repositories).

This fork will solve the problem (as [per this issue](https://github.com/github/linguist/pull/2164))