### PR TITLE
allow option mobileStartScroll

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -279,6 +279,8 @@
 		})());
 
 		if(_isMobile) {
+
+            _mobileOffset = options.mobileStartScroll || 0;
 			_skrollrBody = document.getElementById(options.skrollrBody || DEFAULT_SKROLLRBODY);
 
 			//Detect 3d transform if there's a skrollr-body (only needed for #skrollr-body).
@@ -789,7 +791,7 @@
 
 					var duration = Math.abs(speed / _mobileDeceleration);
 					var targetOffset = speed * duration + 0.5 * _mobileDeceleration * duration * duration;
-					var targetTop = _instance.getScrollTop() - targetOffset;
+                    var targetTop = isNaN(targetOffset) ? _instance.getScrollTop() : _instance.getScrollTop() - targetOffset;
 
 					//Relative duration change for when scrolling above bounds.
 					var targetRatio = 0;


### PR DESCRIPTION
In the mobile context, I want to use a scrolling mechanism outside of the skrollr body because it is attached to a fixed element( which needs to be outside of the skrollr body).

To do so I turn skrollr on and off when I go between the modes.

I would like to remember skrollr's scroll position so I don't have to start at the beginning each time.

The usage would be:
s = skrollr.init({
  forceHeight: false,
  mobileStartScroll: scrollTop
});