### PR TITLE
Respect result of beforerender callback on mobile.

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -1113,12 +1113,6 @@
 			}
 		}
 
-		//That's were we actually "scroll" on mobile.
-		if(_isMobile && _skrollrBody) {
-			//Set the transform ("scroll it").
-			skrollr.setStyle(_skrollrBody, 'transform', 'translate(0, ' + -(_mobileOffset) + 'px) ' + _translateZ);
-		}
-
 		//Did the scroll position even change?
 		if(_forceRender || _lastTop !== renderTop) {
 			//Remember in which direction are we scrolling?
@@ -1140,6 +1134,12 @@
 			if(continueRendering !== false) {
 				//Now actually interpolate all the styles.
 				_calcSteps(renderTop, _instance.getScrollTop());
+				
+				//That's were we actually "scroll" on mobile.
+				if(_isMobile && _skrollrBody) {
+					//Set the transform ("scroll it").
+					skrollr.setStyle(_skrollrBody, 'transform', 'translate(0, ' + -(_mobileOffset) + 'px) ' + _translateZ);
+				}
 
 				//Remember when we last rendered.
 				_lastTop = renderTop;


### PR DESCRIPTION
Render engine currently sets mobile transform position BEFORE checking results of beforerender callback, defeating the purpose of the callback on mobile.

This PR fixes that, and ensures that if beforerender returns FALSE the render action does not happen, even on mobile.