### PR TITLE
Allow for a duration of 0 when scrolling

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -563,15 +563,16 @@
 
 		var now = _now();
 		var scrollTop = _instance.getScrollTop();
+		var duration = options.duration === undefined ? DEFAULT_DURATION : options.duration;
 
 		//Setting this to a new value will automatically cause the current animation to stop, if any.
 		_scrollAnimation = {
 			startTop: scrollTop,
 			topDiff: top - scrollTop,
 			targetTop: top,
-			duration: options.duration || DEFAULT_DURATION,
+			duration: duration,
 			startTime: now,
-			endTime: now + (options.duration || DEFAULT_DURATION),
+			endTime: now + duration,
 			easing: easings[options.easing || DEFAULT_EASING],
 			done: options.done
 		};


### PR DESCRIPTION
Currently, passing a value of `0` for `options.duration` causes the default duration to be used. This makes it difficult to do instantaneous scroll changes.

This PR does an explicit check on `options.duration` so that `0` is not considered the same as an absent value.