### PR TITLE
Added support for options.skrollrBody

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -279,7 +279,13 @@
 		})());
 
 		if(_isMobile) {
-			_skrollrBody = document.getElementById(options.skrollrBody || DEFAULT_SKROLLRBODY);
+
+			// Allow to set the container object directly from init options.
+			if (typeof options.skrollrBody == "object") {
+				_skrollrBody = options.skrollrBody;
+			} else {
+				_skrollrBody = document.getElementById(options.skrollrBody || DEFAULT_SKROLLRBODY);
+			}
 
 			//Detect 3d transform if there's a skrollr-body (only needed for #skrollr-body).
 			if(_skrollrBody) {


### PR DESCRIPTION
This allows options.skrollrBody to be also a DOM node with the container already set. I had to do this because of JQM and its load structure.