### PR TITLE
Add disableMobile and enableMobile public functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,14 @@ When `force` is set to `true`, skrollr will jump to the new position without any
 
 Returns if skrollr runs in mobile mode (see also `mobileCheck` option).
 
+### disableMobile()
+
+Disable mobile event catching, which means skrollr won't move but the click/tap/drag event will bubble up.
+
+### enableMobile()
+
+Re-enable mobile event catching.
+
 ### animateTo(top[, options])
 
 Animates the scroll position from current position to `top`. Possible `options` are

--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -90,6 +90,9 @@
 
 	//Finds all gradients.
 	var rxGradient = /[a-z\-]+-gradient/g;
+	
+	//If mobile event catching is enabled
+	var mobileEnabled = true;
 
 	//Vendor prefix. Will be set once skrollr gets initialized.
 	var theCSSPrefix = '';
@@ -647,6 +650,14 @@
 		return _instance;
 	};
 
+	Skrollr.prototype.disableMobile = function() {
+		mobileEnabled = false;
+	};
+
+	Skrollr.prototype.enableMobile = function() {
+		mobileEnabled = true;
+	};
+
 	Skrollr.prototype.destroy = function() {
 		var cancelAnimFrame = polyfillCAF();
 		cancelAnimFrame(_animFrame);
@@ -713,6 +724,9 @@
 		var deltaTime;
 
 		_addEvent(documentElement, [EVENT_TOUCHSTART, EVENT_TOUCHMOVE, EVENT_TOUCHCANCEL, EVENT_TOUCHEND].join(' '), function(e) {
+			if (!mobileEnabled)
+				return true;
+
 			var touch = e.changedTouches[0];
 
 			currentElement = e.target;


### PR DESCRIPTION
Following this issue:
https://github.com/Prinzhorn/skrollr/issues/675

I had a case when a mobile menu had to scroll because it was too long.
With skrollr, all event where stopped and it was impossible to scroll in the menu.

With this pull request, we can now disabled all event catching on mobile.

The usage is simple:
When the user open the menu, I call skrollr.disableMobile() and it can now scroll in the menu, and skrollr stay where it is
When the user closes the menu, I call skrollr.enableMobile() and everything work like normal.

I updated the README.md to add these 2 functions documentation.

I didn't updated the minified file, neither the HISTORY.md.

I hope it fits the project.
