### PR TITLE
Add symlink to skrollr.js in dist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,15 +37,24 @@ module.exports = function(grunt) {
 					'dist/skrollr.min.js': 'src/skrollr.js'
 				}
 			}
+		},
+		symlink: {
+			all: {
+				expand: true,
+				cwd: 'src/',
+				src: 'skrollr.js',
+				dest: 'dist/'
+			}
 		}
 	});
 
 	//Dependencies.
+	grunt.loadNpmTasks('grunt-contrib-symlink');
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-qunit');
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 
 	//Tasks.
-	grunt.registerTask('default', ['jshint', 'qunit', 'uglify']);
+	grunt.registerTask('default', ['jshint', 'qunit', 'uglify', 'symlink']);
 	grunt.registerTask('travis', ['jshint', 'qunit']);
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "grunt-cli": "~0.1.7",
     "grunt": "~0.4.1",
+    "grunt-contrib-symlink": "^1.0.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-jshint": "~0.3.0",
     "grunt-contrib-qunit": "~0.2.0"


### PR DESCRIPTION
Many popular bower packages release _min_ and _no-min_ files in same folder or _dist_ folder. The reason is that some people may not need _src_ folder so they include _no-min_ in _dist_ too. I added a symlink, so there are no duplicate files in the repository, yet still provide _no-min_ in _dist_ folder as a symlink for handiness.

Reference: [jquery](https://github.com/jquery/jquery), [jquery-ui](https://github.com/jquery/jquery-ui), [bootstrap](https://github.com/twbs/bootstrap), [lodash](https://github.com/lodash/lodash), [d3](https://github.com/mbostock/d3)
