### PR TITLE
Make isMobile public in Global API

### DIFF
--- a/src/skrollr.js
+++ b/src/skrollr.js
@@ -12,6 +12,9 @@
 	 * Global api.
 	 */
 	var skrollr = {
+		isMobile: function() {
+			return (/Android|iPhone|iPad|iPod|BlackBerry/i).test(navigator.userAgent || navigator.vendor || window.opera);
+		},
 		get: function() {
 			return _instance;
 		},
@@ -274,9 +277,7 @@
 		};
 
 		//A custom check function may be passed.
-		_isMobile = ((options.mobileCheck || function() {
-			return (/Android|iPhone|iPad|iPod|BlackBerry/i).test(navigator.userAgent || navigator.vendor || window.opera);
-		})());
+		_isMobile = (options.mobileCheck || skrollr.isMobile)();
 
 		if(_isMobile) {
 			_skrollrBody = document.getElementById(options.skrollrBody || DEFAULT_SKROLLRBODY);


### PR DESCRIPTION
Default function for isMobile should be included in Public API.
We are only making the default function public, everything stays same.
If user defines a custom function inside _init()_, it will respect that decision as usual.

(This change is a request, it's not required but it may help people if they don't want to copy&paste the exact function or use extra libraries for Mobile detection)
